### PR TITLE
Fix the most recently unlocked sector not being saved + misc fixes

### DIFF
--- a/core/src/mindustry/randomizer/techtree/ApLocation.java
+++ b/core/src/mindustry/randomizer/techtree/ApLocation.java
@@ -43,10 +43,10 @@ public class ApLocation extends Block {
             onUnlock();
             Events.fire(new EventType.UnlockEvent(this));
             if (locationId != null) {
-                randomizer.checkLocation(locationId);
                 if (originalContent instanceof SectorPreset) {
                     randomizer.unlockSector(((SectorPreset) originalContent).sector.preset.name);
                 }
+                randomizer.checkLocation(locationId);
             } else {
                 RandomizerMessageHandler.printErrorWithReason(RandomizerConstant.NULL_LOCATION_ID);
             }

--- a/core/src/mindustry/randomizer/ui/ArchipelagoDialog.java
+++ b/core/src/mindustry/randomizer/ui/ArchipelagoDialog.java
@@ -156,17 +156,16 @@ public class ArchipelagoDialog extends BaseDialog {
         archipelagoTable.row();
         archipelagoTable.table(info -> info.add(ChatColor.applyColor(LIGHTGRAY, RandomizerConstant.DEATH_LINK_OPTION)).width(archipelagoTable.getWidth())).get().left();
         archipelagoTable.row();
-        archipelagoTable.image().width(archipelagoTable.getWidth()).color(Color.gray).fillX().height(3).pad(1).colspan(4).padTop(0).padBottom(1).row();
-        archipelagoTable.check(RandomizerConstant.FORCE_DISABLE_DEATH_LINK, settings.getBool(FORCE_DISABLE_DEATH_LINK.value),  bool -> {
+        archipelagoTable.image().width(archipelagoTable.getWidth()).color(Color.gray).fillX().height(3).pad(6).colspan(4).padTop(0).padBottom(1).row();
+        archipelagoTable.check(RandomizerConstant.FORCE_DISABLE_DEATH_LINK, settings.getBool(FORCE_DISABLE_DEATH_LINK.value), bool -> {
             newForceDisableDeathLink = bool;
             forceDeathLinkChanged = true;
-        }).tooltip(RandomizerConstant.FORCE_DISABLE_DEATH_LINK_TOOLTIP).grow().padBottom(1f).size(320f, 60f).get().align(Align.left);
+        }).tooltip(RandomizerConstant.FORCE_DISABLE_DEATH_LINK_TOOLTIP).padBottom(1f).width(320f).get().left(); // increase width to fit text
         archipelagoTable.row();
-        archipelagoTable.check(RandomizerConstant.PROTECT_CAPTURED_SECTOR, settings.getBool(AP_DEATH_LINK_PROTECT_CAPTURED_SECTOR.value),
-                bool -> {
-                     newDeathLinkProtectSector = bool;
-                     deathLinkProtectedSectorChanged = true;
-                }).tooltip(RandomizerConstant.PROTECT_CAPTURED_SECTOR_TOOLTIP).padBottom(1f).get().left();
+        archipelagoTable.check(RandomizerConstant.PROTECT_CAPTURED_SECTOR, settings.getBool(AP_DEATH_LINK_PROTECT_CAPTURED_SECTOR.value), bool -> {
+             newDeathLinkProtectSector = bool;
+             deathLinkProtectedSectorChanged = true;
+        }).tooltip(RandomizerConstant.PROTECT_CAPTURED_SECTOR_TOOLTIP).padBottom(1f).width(320f).get().left(); // increase width to fit text
 
         archipelagoTable.row();
         archipelagoTable.table(info -> info.add(ChatColor.applyColor(LIGHTGRAY, RandomizerConstant.CHAT_OPTIONS)).width(archipelagoTable.getWidth())).padBottom(1f).get().left();


### PR DESCRIPTION
This fixes the issue that could cause playthroughs to become softlocked if they closed the game without the state saving again for whatever reason (e.g. unlocking a research) after unlocking a sector, since the state was saved locally before the location was actually added to the list of done locations

Also, fixed the annoying button that looked funny on the connection screen, cause it was annoying me